### PR TITLE
feat: use title as short url

### DIFF
--- a/server/controllers/common.js
+++ b/server/controllers/common.js
@@ -562,6 +562,10 @@ router.get('/*', async (req, res, next) => {
         _.set(res.locals, 'pageMeta.title', 'Welcome')
         res.render('welcome', { locale: pageArgs.locale })
       } else {
+        const pages = await WIKI.models.pages.getPageIDWithTitle(pageArgs.path)
+        if (pages.length > 0) {
+          return res.redirect(`/${pageArgs.locale}/${pages[0].path}`)
+        }
         _.set(res.locals, 'pageMeta.title', 'Page Not Found')
         if (effectivePermissions.pages.write) {
           res.status(404).render('new', { path: pageArgs.path, locale: pageArgs.locale })

--- a/server/models/pages.js
+++ b/server/models/pages.js
@@ -969,6 +969,17 @@ module.exports = class Page extends Model {
   }
 
   /**
+    * 
+    * @param {String} title Page title
+    * @returns {Promise} Promise of the Page id and path
+    */
+  static async getPageIDWithTitle(title) {
+    return WIKI.models.pages.query()
+      .column(['pages.id', 'pages.path'])
+      .where({'pages.title': title})
+  }
+
+  /**
    * Fetch an Existing Page from the Database
    *
    * @param {Object} opts Page Properties


### PR DESCRIPTION
The wiki should hava short url.

Pages can be view using keyword instead of long file path.

like https://zh.wikipedia.org/wiki/JavaScript instead of https://zh.wikipedia.org/wiki/Programming_language/Scripting_languages/JavaScript.